### PR TITLE
add presenting index

### DIFF
--- a/GUITabPagerViewController/Classes/GUITabPagerViewController.h
+++ b/GUITabPagerViewController/Classes/GUITabPagerViewController.h
@@ -21,6 +21,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (strong, nonatomic) GUITabScrollView *header;
 
+@property (assign, nonatomic) NSInteger presentingIndex;
+
 - (void)reloadData;
 - (NSInteger)selectedIndex;
 

--- a/GUITabPagerViewController/Classes/GUITabPagerViewController.m
+++ b/GUITabPagerViewController/Classes/GUITabPagerViewController.m
@@ -148,11 +148,19 @@
 
     [[[self pageViewController] view] setFrame:frame];
 
-    [self.pageViewController setViewControllers:@[[self viewControllers][0]]
+    [self.pageViewController setViewControllers:@[[self viewControllers][self.presentingIndex]]
                                       direction:UIPageViewControllerNavigationDirectionReverse
                                        animated:NO
                                      completion:nil];
-    [self setSelectedIndex:0];
+    [self setSelectedIndex:self.presentingIndex];
+}
+
+- (NSInteger)presentingIndex
+{
+    if (!_presentingIndex) {
+        _presentingIndex = 0;
+    }
+    return _presentingIndex;
 }
 
 - (void)reloadTabs {


### PR DESCRIPTION
add presenting index for default presenting viewController's index not equal to zero.
otherwise if the default presenting index not zero, the viewDidLoad() in tabPagerViewControllers[0] still get called.
may affect tracking code kind of stuff.